### PR TITLE
Editing issue resolved with row item observing

### DIFF
--- a/Test iOS App/.swiftlint.yml
+++ b/Test iOS App/.swiftlint.yml
@@ -1,0 +1,3 @@
+disabled_rules:
+    - all
+

--- a/Test iOS App/Test iOS App.xcodeproj/project.pbxproj
+++ b/Test iOS App/Test iOS App.xcodeproj/project.pbxproj
@@ -6,6 +6,10 @@
 	objectVersion = 77;
 	objects = {
 
+/* Begin PBXBuildFile section */
+		7BDA4CFA2D2E8FD800A9CF36 /* .swiftlint.yml in Resources */ = {isa = PBXBuildFile; fileRef = 7BDA4CF92D2E8FD800A9CF36 /* .swiftlint.yml */; };
+/* End PBXBuildFile section */
+
 /* Begin PBXContainerItemProxy section */
 		49A246D82D15341D0067D439 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -27,6 +31,7 @@
 		49A246C22D15341B0067D439 /* Test iOS App.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "Test iOS App.app"; sourceTree = BUILT_PRODUCTS_DIR; };
 		49A246D72D15341D0067D439 /* Test iOS AppTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Test iOS AppTests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 		49A246E12D15341D0067D439 /* Test iOS AppUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "Test iOS AppUITests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		7BDA4CF92D2E8FD800A9CF36 /* .swiftlint.yml */ = {isa = PBXFileReference; lastKnownFileType = text.yaml; path = .swiftlint.yml; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedRootGroup section */
@@ -75,6 +80,7 @@
 		49A246B92D15341B0067D439 = {
 			isa = PBXGroup;
 			children = (
+				7BDA4CF92D2E8FD800A9CF36 /* .swiftlint.yml */,
 				49A246C42D15341B0067D439 /* Test iOS App */,
 				49A246DA2D15341D0067D439 /* Test iOS AppTests */,
 				49A246E42D15341D0067D439 /* Test iOS AppUITests */,
@@ -212,6 +218,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7BDA4CFA2D2E8FD800A9CF36 /* .swiftlint.yml in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Test iOS App/Test iOS App/RowView.swift
+++ b/Test iOS App/Test iOS App/RowView.swift
@@ -8,23 +8,29 @@
 import SwiftUI
 
 struct RowView: View {
-    let item: Item
-    
-    var body: some View {
-        VStack {
-            HStack {
-                Text(item.title ?? "Untitled")
-                    .font(.title)
-                Spacer()
-            }
-            HStack {
-                Text(item.timestamp!, formatter: itemFormatter)
-                    .font(.subheadline)
-                Spacer()
-            }
-        }
-    }
-}
+          @ObservedObject var item: Item
+          
+          var body: some View {
+              VStack {
+                  HStack {
+                      Text(item.title ?? "Untitled")
+                          .font(.title)
+                      Spacer()
+                  }
+                  HStack {
+                      if let timestamp = item.timestamp {
+                          Text(timestamp, formatter: itemFormatter)
+                              .font(.subheadline)
+                      } else {
+                          Text("No timestamp available")
+                              .font(.subheadline)
+                              .foregroundColor(.gray)
+                      }
+                      Spacer()
+                  }
+              }
+          }
+      }
 
 private let itemFormatter: DateFormatter = {
     let formatter = DateFormatter()


### PR DESCRIPTION
@jch5f 
In this case, there is a much simpler solution, make the item attribute of the RowView struct an ObservedObject.

**Agreed. If we code like this for the row.** 
----
Explanation :
 - The RowView was not automatically get updated when the item object in Core Data was changed. This caused inconsistencies in the UI, requiring either a manual refresh or a an app restart to see changes.
 - The 'delete item' did not sync changes between the viewContext and the FetchedResults. This occasionally caused deleted rows to remain visible in the UI, leading to confusion and a poor user experience.
 
 -------
resolved: 
 - The RowView now observes its Item using @ObservedObject. This ensures that any changes to Item properties are automatically reflected in the UI without requiring manual refresh mechanisms or app restarts.
 - Additionally, added the swift lint, too. For the time concerns, disabled all the rules as of now. 
 Let me know if any other requirements/queries on this. 